### PR TITLE
fix: add correct permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: windows-latest


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration for releases. The change adds explicit permissions for the workflow to write to repository contents, which is necessary for release automation.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R10): Added `permissions` section with `contents: write` to allow the workflow to modify repository contents during release.